### PR TITLE
Add report-issue instructions to README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -16,6 +16,10 @@ Learn more at [chainguard.dev/actions](https://www.chainguard.dev/actions).
 
 To request a new action, [open an issue](https://github.com/chainguard-actions/.github/issues/new?template=new-action.yml).
 
+## Report an Issue
+
+If an action isn't working as expected, [open an issue](https://github.com/chainguard-actions/.github/issues/new?template=action-issue.yml) and include the action reference, a description of the problem, and steps to reproduce.
+
 ## Contact
 
 For questions or issues, reach out to interest@chainguard.dev.


### PR DESCRIPTION
## Summary

- Adds a "Report an Issue" section to the README linking to the new `action-issue.yml` template (introduced in #3)
- Gives customers a clear path for reporting problems with existing actions

## Dependency

Best merged after #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)