### PR TITLE
add sts policies for gh iac automation

### DIFF
--- a/.github/chainguard/audit-gh-automation.sts.yaml
+++ b/.github/chainguard/audit-gh-automation.sts.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/infra:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: chainguard-dev/infra/.github/workflows/audit-gh-automation.yaml@refs/heads/main
+
+permissions:
+  members: read # to read GitHub members
+  metadata: read # to read metadata about the org
+
+repositories: [] # Act over all of the repos in the org.

--- a/.github/chainguard/sync-github.sts.yaml
+++ b/.github/chainguard/sync-github.sts.yaml
@@ -1,0 +1,14 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/infra:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: chainguard-dev/infra/.github/workflows/.terraform.yaml@.*
+
+permissions:
+  administration: write # required to manage the repository
+  members: write # to add/remove GitHub members
+  metadata: read # to read metadata about the org
+
+repositories: [] # Act over all of the repos in the org.

--- a/.github/chainguard/verify-github.sts.yaml
+++ b/.github/chainguard/verify-github.sts.yaml
@@ -1,0 +1,14 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:chainguard-dev/infra:pull_request
+claim_pattern:
+  job_workflow_ref: chainguard-dev/infra/.github/workflows/.terraform.yaml@.*
+
+permissions:
+  administration: read # required to read the repository
+  members: read # to read GitHub members information
+  metadata: read # to read metadata about the org
+
+repositories: [] # Act over all of the repos in the org.


### PR DESCRIPTION
related to https://linear.app/chainguard/issue/ACDC-34/bootstrap-chainguard-actions-gh-org-into-the-gh-iac-automation
and https://github.com/chainguard-dev/infra/pull/2472